### PR TITLE
Update backend-ci.yml

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   backend-test:
     runs-on: ubuntu-latest
-    if: ${{ github.ref != 'refs/heads/frontend' }}
+    if: contains(github.event.pull_request.head.repo.name, 'lnm-backend/**')
     steps:
       # Шаг 1: Клонирование репозитория
       - name: Checkout code


### PR DESCRIPTION
## Описание изменений
Убраны фильтры пути (которые `on: pull_request: paths: `)

## Выполненные задачи
- `contains(github.event.pull_request.head.repo.name, 'lnm-backend/**')`

## Как протестировать?
- Пайплайн для бэкенда должен запускаться только при изменениях 'lnm-backend/**'.
- Надеюсь, что он перестанет виснуть