### PR TITLE
Update frontend-ci.yml

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,17 +5,14 @@ on:
     branches:
       - main
       - frontend
-    paths:
-      - 'lnm-frontend/**'
   push:
     branches:
       - frontend
-    paths:
-      - 'lnm-frontend/**'
 
 jobs:
   lint-frontend:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.head.repo.name, 'lnm-frontend/**')
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -39,6 +36,8 @@ jobs:
         
   test-frontend:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.head.repo.name, 'lnm-frontend/**')
+    needs: lint-frontend
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
## Описание изменений
Убраны фильтры пути (которые `on: pull_request: paths: `)

## Выполненные задачи
- `contains(github.event.pull_request.head.repo.name, 'lnm-frontend/**')`

## Как протестировать?
- Пайплайн для бэкенда должен запускаться только при изменениях 'lnm-frontend/**'.
- Надеюсь, что он перестанет виснуть
