### PR TITLE
update node version on main-ci

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '23' # Adjust as needed
 

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18' # Adjust as needed
+          node-version: '23' # Adjust as needed
 
       - name: Install dependencies
         working-directory: ./lnm-frontend


### PR DESCRIPTION
## Описание изменений
Обновлена версия `Node.js` в пайплайне `main-ci.yml`.

## Выполненные задачи
- `actions/setup-node@v2` -> `actions/setup-node@v4`
- `node-version: '18'` -> `node-version: '23'`

## Как протестировать?
Проверить, поддерживает ли данный action данную версию node, собирается ли проект с данной версией node
